### PR TITLE
[WIP] Setup github actions to build & push docker image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,10 +21,10 @@ jobs:
       with:
         registries: 783616723547
 
-    - name: Absolutely ridiculous hack lol
+    - name: Try get contents of docker config forreal
       run: |
-        sed -i.bak "s/***.dkr.ecr./783616723547.dkr.ecr./" ~/.docker/config.json
-        cat ~/.docker/config.json
+        find ~/.docker
+        cat ~/.docker/config.json | base64
 
     - name: update jupyter dependencies with repo2docker
       uses: yuvipanda/repo2docker-action@allow-cred-helpers

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,16 @@
+name: Build Notebook Container
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: checkout files in repo
+      uses: actions/checkout@main
+
+    - name: update jupyter dependencies with repo2docker
+      uses: jupyterhub/repo2docker-action@master
+      with: # make sure username & password/token matches your registry
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        IMAGE_NAME: 783616723547.dkr.ecr.us-west-2.amazonaws.com/user-image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,11 @@ jobs:
       with:
         registries: 783616723547
 
+    - name: What is config/
+      run: |
+        find ~/.docker
+        cat ~/.docker/config.json
+
     - name: update jupyter dependencies with repo2docker
       uses: yuvipanda/repo2docker-action@allow-cred-helpers
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
       with:
-        registries: 783616723547.dkr.ecr.us-west-2.amazonaws.com
+        registries: 783616723547
 
     - name: update jupyter dependencies with repo2docker
       uses: yuvipanda/repo2docker-action@allow-cred-helpers

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,8 +27,8 @@ jobs:
         pip install jupyter-repo2docker
         TAG=$(echo "${GITHUB_SHA}" | cut -c1-12)
         IMAGE="783616723547.dkr.ecr.us-west-2.amazonaws.com/user-image"
-        find ~/.docker
         jupyter-repo2docker \
           --image-name ${IMAGE}:${TAG} \
           --user-id 1000 --user-name jovyan \
-          --push .
+          --no-run --push \
+          .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,4 +31,5 @@ jobs:
       with:
         DOCKER_USERNAME: ""
         DOCKER_PASSWORD: ""
-        IMAGE_NAME: 783616723547.dkr.ecr.us-west-2.amazonaws.com/user-image
+        DOCKER_REGISTRY: 783616723547.dkr.ecr.us-west-2.amazonaws.com
+        IMAGE_NAME: user-image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,9 +8,15 @@ jobs:
     - name: checkout files in repo
       uses: actions/checkout@main
 
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+
     - name: update jupyter dependencies with repo2docker
       uses: jupyterhub/repo2docker-action@master
-      with: # make sure username & password/token matches your registry
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      with:
         IMAGE_NAME: 783616723547.dkr.ecr.us-west-2.amazonaws.com/user-image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,8 @@ jobs:
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
+      with:
+        registries: 783616723547.dkr.ecr.us-west-2.amazonaws.com
 
     - name: update jupyter dependencies with repo2docker
       uses: yuvipanda/repo2docker-action@allow-cred-helpers

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: update jupyter dependencies with repo2docker
-      uses: jupyterhub/repo2docker-action@master
+      uses: yuvipanda/repo2docker-action@allow-cred-helpers
       with:
         DOCKER_USERNAME: ""
         DOCKER_PASSWORD: ""

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,9 +21,9 @@ jobs:
       with:
         registries: 783616723547
 
-    - name: What is config/
+    - name: Absolutely ridiculous hack lol
       run: |
-        find ~/.docker
+        sed -i.bak "s/***.dkr.ecr./783616723547.dkr.ecr./" ~/.docker/config.json
         cat ~/.docker/config.json
 
     - name: update jupyter dependencies with repo2docker

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,16 +15,20 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
-    - name: Setup ecr-login
-      run: |
-        sudo apt update > /dev/null
-        sudo apt install amazon-ecr-credential-helper ---yes > /dev/null
-        echo '{ "credsStore": "ecr-login" } ' > ~/.docker/config.json
-
-    - name: update jupyter dependencies with repo2docker
-      uses: yuvipanda/repo2docker-action@allow-cred-helpers
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
       with:
-        DOCKER_USERNAME: ""
-        DOCKER_PASSWORD: ""
-        DOCKER_REGISTRY: 783616723547.dkr.ecr.us-west-2.amazonaws.com
-        IMAGE_NAME: user-image
+        registries: 783616723547
+
+    - name: Setup repo2docker
+      run: |
+        apt update > /dev/null && apt install python3 python3-pip
+        pip install jupyter-repo2docker
+        TAG=$(echo "${GITHUB_SHA}" | cut -c1-12)
+        IMAGE="783616723547.dkr.ecr.us-west-2.amazonaws.com/user-image"
+        find ~/.docker
+        jupyter-repo2docker \
+          --image-name ${IMAGE}:${TAG} \
+          --user-id 1000 --user-name jovyan \
+          --push .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,13 +8,16 @@ jobs:
     - name: checkout files in repo
       uses: actions/checkout@main
 
-    - name: Login to Amazon ECR
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
 
     - name: update jupyter dependencies with repo2docker
       uses: jupyterhub/repo2docker-action@master

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,4 +22,6 @@ jobs:
     - name: update jupyter dependencies with repo2docker
       uses: jupyterhub/repo2docker-action@master
       with:
+        DOCKER_USERNAME: ""
+        DOCKER_PASSWORD: ""
         IMAGE_NAME: 783616723547.dkr.ecr.us-west-2.amazonaws.com/user-image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,12 @@ jobs:
         apt update > /dev/null && apt install python3 python3-pip
         pip install jupyter-repo2docker
         TAG=$(echo "${GITHUB_SHA}" | cut -c1-12)
-        IMAGE="783616723547.dkr.ecr.us-west-2.amazonaws.com/user-image"
+        IMAGE_NAME="783616723547.dkr.ecr.us-west-2.amazonaws.com/user-image"
+        IMAGE="${IMAGE_NAME}:${TAG}"
         jupyter-repo2docker \
-          --image-name ${IMAGE}:${TAG} \
+          --image-name ${IMAGE} \
           --user-id 1000 --user-name jovyan \
           --no-run --push \
           .
+        docker tag ${IMAGE} "${IMAGE_NAME}:latest"
+        docker push ${IMAGE_NAME}:latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,10 @@
 name: Build Notebook Container
-on: [push]
+on:
+  push:
+    paths:
+    - requirements.txt
+    - environment.yml
+    - .github/*
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,16 +15,11 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
-    - name: Login to Amazon ECR
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
-      with:
-        registries: 783616723547
-
-    - name: Try get contents of docker config forreal
+    - name: Setup ecr-login
       run: |
-        find ~/.docker
-        cat ~/.docker/config.json | base64
+        sudo apt update > /dev/null
+        sudo apt install amazon-ecr-credential-helper ---yes > /dev/null
+        echo '{ "credsStore": "ecr-login" } ' > ~/.docker/config.json
 
     - name: update jupyter dependencies with repo2docker
       uses: yuvipanda/repo2docker-action@allow-cred-helpers

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
     paths:
     - requirements.txt
     - environment.yml
-    - .github/*
+    - .github/workflows/*
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will automatically build and push a docker image for use with
openscapes.2i2c.cloud JupyterHub whenever the `requirements.txt`
or `environment.yml` change. The new image will still need to
be  deployed by 2i2c staff though.
